### PR TITLE
ci: Fix the typo in `create_tag.yml`. It should be `contents` instead of `content`

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -45,7 +45,7 @@ jobs:
     if: needs.create_tag.outputs.new_tag != '' && needs.create_tag.outputs.new_tag != 'undefined'
     uses: ./.github/workflows/release.yml
     permissions:
-      content: write
+      contents: write
       id-token: write
     with:
       tag_name: ${{ needs.create_tag.outputs.new_tag }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal configuration updates to CI/CD workflows for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->