### PR TITLE
ci: Change the default release cycle

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -2,7 +2,7 @@ name: Create Tag
 
 on:
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: "0 0 * * 2"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This changes the release cycle from the first day of every month to every Tuesday. This allows a more frequent update of the package, and Tuesday would be the best day of the week. The team can address any high-priority issues from the weekend on Monday, finalize merges, tagging, and testing without rushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated tagging workflow schedule to run every Tuesday at midnight instead of on the first day of each month.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->