### PR TITLE
docs: Fix the instructions about trusted publishing

### DIFF
--- a/docs/user_guide/ci_cd.md
+++ b/docs/user_guide/ci_cd.md
@@ -193,7 +193,7 @@ Use [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) instead
 3. Add GitHub as trusted publisher:
    - Owner: `your-username`
    - Repository: `your-repo-name`
-   - Workflow: `publish.yml`
+   - Workflow: `create_tag.yml` (for automatic releases) and `publish.yml` (for manual publishes)
    - Environment: `production` (or `testpypi` for TestPyPI)
 
 No secrets or tokens needed!


### PR DESCRIPTION
For automatic releases, the workflow file should be `create_tag.yml`. `publish.yml` is for manual publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Trusted Publishing configuration guidance to document support for both automatic tag-based release workflows and manual publishing options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->