### PR TITLE
ci: Execute the publishing in `create_tag.yml` directly instead of through a workflow call

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -49,3 +49,73 @@ jobs:
       id-token: write
     with:
       tag_name: ${{ needs.create_tag.outputs.new_tag }}
+
+  build:
+    needs:
+      - create_tag
+      - release
+    if: needs.create_tag.outputs.new_tag != '' && needs.create_tag.outputs.new_tag != 'undefined'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.create_tag.outputs.new_tag }}
+          fetch-depth: 0
+
+      - name: Output build information
+        run: |
+          echo "### Publishing Build :package:" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version tag**: ${{ needs.create_tag.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.10-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.10-
+            ${{ runner.os }}-pip-
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Generate attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.13.0
+        with:
+          packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,3 @@ jobs:
           body: ${{ steps.changelog.outputs.content }}
           draft: false
           prerelease: ${{ contains(inputs.tag_name || github.event.inputs.tag_name, 'alpha') || contains(inputs.tag_name || github.event.inputs.tag_name, 'beta') }}
-
-  publish:
-    needs: release
-    uses: ./.github/workflows/publish.yml
-    permissions:
-      contents: write
-      id-token: write
-    with:
-      tag_name: ${{ inputs.tag_name || github.event.inputs.tag_name }}


### PR DESCRIPTION
PyPI trusted publishing does not work when the publishing is triggered with a workflow call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated build and publication to PyPI is now triggered immediately after tag creation, streamlining the release process.
  * Optimized release workflow by consolidating build and publish steps into a cohesive pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->