### PR TITLE
chore: Set the output of CLI loggers to `stderr`

### DIFF
--- a/src/python_package_template/cli/main.py
+++ b/src/python_package_template/cli/main.py
@@ -43,7 +43,7 @@ def setup_logging(level: LoggingLevel = LoggingLevel.INFO) -> None:
 
     logger.setLevel(level.value)
 
-    console = Console()
+    console = Console(stderr=True)
 
     # Remove any existing handlers to ensure RichHandler is used
     for h in logger.handlers[:]:  # Use slice copy to avoid modification during iteration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logging output to direct messages to standard error stream for improved output separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->