### PR TITLE
chore: Replace `detect-secrets` with the actively maintained `gitleaks`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,10 +98,7 @@ repos:
           # Update the uv lockfile
           - id: uv-lock
 
-    - repo: https://github.com/Yelp/detect-secrets
-      rev: v1.5.0 # Use the latest stable version
+    - repo: https://github.com/gitleaks/gitleaks
+      rev: v8.30.1
       hooks:
-          - id: detect-secrets
-            name: Detect secrets within the codebase
-            description:
-                Detect and block secrets from committing to the codebase
+          - id: gitleaks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hook configuration for enhanced security scanning capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->