### PR TITLE
feat(deps): add SPEC 0 dependency support policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,17 @@ jobs:
     test:
         strategy:
             matrix:
+                # Latest resolutions run everywhere; the SPEC 0 minimum
+                # (lowest-direct) runs on ubuntu with the oldest supported
+                # Python, since floor versions predate newer interpreters'
+                # wheels.
                 python-version: ['3.12', '3.13', '3.14']
                 os: [ubuntu-latest, windows-latest, macos-latest]
+                resolution: [highest]
+                include:
+                    - os: ubuntu-latest
+                      python-version: '3.12'
+                      resolution: lowest-direct
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -24,10 +33,18 @@ jobs:
                   enable-cache: 'true'
 
             - name: Install dependencies
-              run: uv sync --group dev --frozen
+              shell: bash
+              env:
+                  RESOLUTION: ${{ matrix.resolution }}
+              run: |
+                  if [ "$RESOLUTION" = "lowest-direct" ]; then
+                      uv sync --group dev --upgrade --resolution lowest-direct
+                  else
+                      uv sync --group dev --upgrade
+                  fi
 
             - name: Run tests with pytest
-              run: uv run --frozen pytest
+              run: uv run --no-sync pytest
 
             - name: Upload coverage to Codecov
               if: ${{ !cancelled() }}

--- a/.github/workflows/support_floor_update.yml
+++ b/.github/workflows/support_floor_update.yml
@@ -1,0 +1,64 @@
+name: Support floor update
+
+on:
+    schedule:
+        - cron: '0 6 1 * *' # monthly, 1st at 06:00 UTC
+    workflow_dispatch:
+
+concurrency:
+    group: support-floor-update
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+
+jobs:
+    update-floors:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  persist-credentials: false
+
+            - name: Apply support policy (spec0, from pyproject tool table)
+              id: policy
+              uses: isaac-cf-wong/dependency-support-policy-action@47e04ce9b6fd130812d05c31412e15a14ee9781e # v0.1.0
+              with:
+                  mode: update
+
+            # PRs created with the default GITHUB_TOKEN do not trigger CI, so
+            # the PR is created with a GitHub App installation token instead.
+            - name: Mint app token
+              if: steps.policy.outputs.changed == 'true'
+              id: app-token
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+              with:
+                  app-id: ${{ vars.APP_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
+
+            - name: Create or update pull request
+              if: steps.policy.outputs.changed == 'true'
+              id: pr
+              uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  branch: dependency-support-policy/update
+                  title: 'chore(deps): raise minimum supported versions'
+                  commit-message:
+                      'chore(deps): raise minimum supported versions'
+                  body: |
+                      Automated rolling support-floor update (SPEC 0).
+
+                      ```json
+                      ${{ steps.policy.outputs.dependency-floors-changed }}
+                      ```
+                  labels: dependencies
+
+            - name: Enable auto-merge
+              if: steps.pr.outputs.pull-request-number
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  PR_NUMBER: ${{ steps.pr.outputs.pull-request-number }}
+              run: gh pr merge --squash --auto "$PR_NUMBER"

--- a/docs/template_documentation/user_guide/ci_cd.md
+++ b/docs/template_documentation/user_guide/ci_cd.md
@@ -19,6 +19,8 @@ security analysis, releases, documentation, and optional PyPI publishing.
   (`documentation.yml`)
 - **Manual publish** — `publish.yml` and `publish_testpypi.yml` with
   `workflow_dispatch`
+- **Support floor update** — monthly SPEC 0 rolling bump of runtime lower bounds
+  (`support_floor_update.yml`)
 
 Linting and formatting are enforced locally via **prek** using
 `.pre-commit-config.yaml`, and on pull requests via **pre-commit.ci**, not via a
@@ -31,11 +33,18 @@ separate job in `ci.yml`. Add a workflow job if you want Ruff in CI as well.
 **Triggers:** `push` and `pull_request` to `main`, plus `workflow_dispatch` and
 `workflow_call`.
 
-**Steps:** checkout → `uv` → `uv sync --extra test,ci --frozen` →
-`uv run pytest` → Codecov upload.
+**Steps:** checkout → `uv` → `uv sync --group dev` → `uv run pytest` → Codecov
+upload.
+
+**Matrix:** the `highest` resolution runs on Linux, macOS, and Windows for
+Python 3.12–3.14. One extra `lowest-direct` cell (Ubuntu, Python 3.12) resolves
+every direct dependency to its declared lower bound, so the SPEC 0 support
+floors in `pyproject.toml` are proven to actually import and pass tests. Both
+paths use `--upgrade` (not `--frozen`) so CI tests real resolutions rather than
+the committed lock.
 
 **Branch protection:** require the matrix jobs you care about, for example
-`test (ubuntu-latest, 3.12)` (exact names appear in the Actions UI).
+`test (ubuntu-latest, 3.12, highest)` (exact names appear in the Actions UI).
 
 ### `codeql.yml` (CodeQL Advanced)
 
@@ -94,6 +103,43 @@ the `site/` directory to GitHub Pages.
 Build with `uv build`, smoke-test artifacts, then `uv publish`. These workflows
 also use `continue-on-error: true` on the publish step so the template stays
 green until you configure PyPI trusted publishing and GitHub environments.
+
+### `support_floor_update.yml` (Support floor update)
+
+**Triggers:** `cron: '0 6 1 * *'` (monthly, 1st at 06:00 UTC) and
+`workflow_dispatch`.
+
+Runs `isaac-cf-wong/dependency-support-policy-action` in `update` mode. It reads
+`[tool.dependency-support-policy]` from `pyproject.toml`, raises runtime lower
+bounds that have aged past the SPEC 0 window, and opens an auto-merging PR when
+anything changed. See [Dependency management](#dependency-management-spec-0).
+
+## Dependency management (SPEC 0)
+
+Runtime lower bounds follow
+[SPEC 0](https://scientific-python.org/specs/spec-0000/): each dependency's
+minimum supported version rolls forward on a fixed schedule rather than tracking
+the latest release. Three pieces cooperate:
+
+- **`[tool.dependency-support-policy]` in `pyproject.toml`** — declares the
+  policy (`spec0`), which groups it manages (`project`), and `lock = "minimal"`.
+  Add `exclude = ["..."]` for ecosystem siblings you release in lockstep and
+  want kept at latest.
+- **`support_floor_update.yml`** — the monthly workflow that computes and
+  applies the new floors and opens a PR.
+- **`renovate.json`** — its first `packageRule` disables Renovate for
+  `project.dependencies` / `project.optional-dependencies` so the two systems do
+  not fight. Renovate still manages dev tooling, GitHub Actions, pre-commit, and
+  the lock file. To keep a sibling package Renovate-managed, add it as
+  `"!package-name"` under `matchPackageNames` on that rule and also list it in
+  the policy `exclude`.
+
+CI proves the floors are real: the `lowest-direct` matrix cell installs every
+direct dependency at its declared minimum and runs the test suite.
+
+The App token step needs repository variable `APP_ID` and secret
+`APP_PRIVATE_KEY` (a GitHub App with contents + pull-requests write). Without
+them the update step still runs but PR creation is skipped.
 
 ## Release process
 
@@ -166,7 +212,10 @@ Remove or gate the `codeql` job in `scheduled_release.yml` instead of editing
 
 ### CI fails
 
-- Reproduce with `uv sync --extra test,ci --frozen` then `uv run pytest`
+- Reproduce with `uv sync --group dev --upgrade` then `uv run pytest`
+- For a `lowest-direct` failure, reproduce with
+  `uv sync --group dev --upgrade --resolution lowest-direct` — a floor is too
+  low
 - Inspect the failing OS / Python cell in the matrix
 
 ### Scheduled release does nothing

--- a/docs/template_documentation/user_guide/packaging.md
+++ b/docs/template_documentation/user_guide/packaging.md
@@ -147,7 +147,10 @@ uv publish --publish-url https://test.pypi.org/legacy/
 
 ### Adding a New Dependency
 
-1. Add to `dependencies` or an optional group in `pyproject.toml`
+1. Add to `dependencies` or an optional group in `pyproject.toml` with a
+   lower-bound pin (`pkg>=X.Y`) — runtime floors are governed by the SPEC 0
+   support policy (see
+   [CI/CD and releases](ci_cd.md#dependency-management-spec-0))
 2. Update your environment: `uv pip install -e ".[dev]"` (or equivalent)
 3. Test that it works
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,16 @@ Tracker = "https://github.com/isaac-cf-wong/python-package-template/issues"
 Home = "https://github.com/isaac-cf-wong/python-package-template"
 "Release Notes" = "https://github.com/isaac-cf-wong/python-package-template/releases"
 
+[tool.dependency-support-policy]
+# Rolling support floors (SPEC 0): runtime lower bounds are raised on a schedule
+# by the support_floor_update.yml workflow, not by Renovate. See renovate.json.
+policy = "spec0"
+groups = ["project"]
+lock = "minimal"
+# For packages with ecosystem siblings released in lockstep, exclude them here
+# and let Renovate keep them at latest, e.g.:
+# exclude = ["my-sibling-package"]
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,15 @@
     "packageRules": [
         {
             "matchManagers": ["pep621"],
+            "matchDepTypes": [
+                "project.dependencies",
+                "project.optional-dependencies"
+            ],
+            "description": "Runtime lower bounds are owned by the dependency-support-policy (SPEC 0) workflow. Add ecosystem siblings as '!package-name' here to keep them Renovate-bumped to latest.",
+            "enabled": false
+        },
+        {
+            "matchManagers": ["pep621"],
             "matchUpdateTypes": ["patch", "minor"],
             "groupName": "runtime minor & patch",
             "minimumReleaseAge": "3 days",


### PR DESCRIPTION
Port the rolling dependency-support-floor policy from gwmock:

- pyproject.toml: [tool.dependency-support-policy] table (spec0, project group, minimal lock)
- support_floor_update.yml: monthly workflow that raises runtime lower bounds and opens an auto-merge PR via a GitHub App token
- renovate.json: disable Renovate on project runtime deps so it does not fight the policy workflow; dev tooling / actions / lockfile stay managed
- ci.yml: add a lowest-direct matrix cell proving the declared floors install and pass; switch to --upgrade resolutions
- docs: document the policy and the new workflow