### PR TITLE
feat(ci): gate PyPI/TestPyPI publish and docs deploy behind repo variables

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        # Set the repository variable DEPLOY_DOCS to "true" once GitHub Pages
+        # is enabled (Settings -> Pages -> Source: GitHub Actions).
+        if: vars.DEPLOY_DOCS == 'true'
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,9 @@ jobs:
     publish-to-pypi:
         needs: build
         runs-on: ubuntu-latest
+        # Set the repository variable PUBLISH_TO_PYPI to "true" once the
+        # 'pypi' environment and PyPI trusted publishing are configured.
+        if: vars.PUBLISH_TO_PYPI == 'true'
         environment: pypi
         permissions:
             id-token: write
@@ -62,9 +65,5 @@ jobs:
 
             - name: Publish to PyPI
               uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
-              # Remove this line if you want the workflow to fail on publish errors
-              # This is added for this template only since the environment 'pypi' is
-              # not created to avoid publishing
-              continue-on-error: true
               with:
                   packages-dir: dist/

--- a/.github/workflows/publish_testpypi.yml
+++ b/.github/workflows/publish_testpypi.yml
@@ -66,6 +66,9 @@ jobs:
     publish-to-testpypi:
         needs: build
         runs-on: ubuntu-latest
+        # Set the repository variable PUBLISH_TO_TESTPYPI to "true" once the
+        # 'testpypi' environment and TestPyPI trusted publishing are configured.
+        if: vars.PUBLISH_TO_TESTPYPI == 'true'
         environment: testpypi
         permissions:
             id-token: write
@@ -79,10 +82,6 @@ jobs:
 
             - name: Publish to TestPyPI
               uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
-              # Remove this line if you want the workflow to fail on publish errors
-              # This is added for this template only since the environment 'testpypi' is
-              # not created to avoid publishing
-              continue-on-error: true
               with:
                   repository-url: https://test.pypi.org/legacy/
                   packages-dir: dist/

--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -100,6 +100,9 @@ jobs:
     publish:
         needs: [release, create_tag]
         runs-on: ubuntu-latest
+        # Set the repository variable PUBLISH_TO_PYPI to "true" once the
+        # 'pypi' environment and PyPI trusted publishing are configured.
+        if: vars.PUBLISH_TO_PYPI == 'true'
         environment:
             name: pypi
         permissions:
@@ -135,8 +138,4 @@ jobs:
                   tests/smoke_test.py
 
             - name: Publish
-              # Remove this line if you want the workflow to fail on publish errors
-              # This is added for this template only since the environment 'pypi' is
-              # not created to avoid publishing
-              continue-on-error: true
               run: uv publish

--- a/docs/template_documentation/user_guide/ci_cd.md
+++ b/docs/template_documentation/user_guide/ci_cd.md
@@ -69,9 +69,9 @@ When there are new commits since the latest tag:
 1. Calls `ci.yml` and `codeql.yml`
 2. Bumps the next semantic tag with `git-cliff` / `uv run git-cliff`
 3. Calls `release.yml` with that tag
-4. Builds wheels, runs smoke tests, and attempts `uv publish` against the
-   **`pypi`** environment (with `continue-on-error: true` so missing setup does
-   not fail the template)
+4. If the repository variable `PUBLISH_TO_PYPI` is `"true"`, builds wheels, runs
+   smoke tests, and runs `uv publish` against the **`pypi`** environment.
+   Otherwise the `publish` job is skipped entirely.
 
 ### `release.yml` (Release)
 
@@ -94,15 +94,17 @@ changelog from git-cliff.
 **Triggers:** `push` to `main` and `workflow_dispatch`.
 
 Runs `uv sync --extra docs --frozen` and `uv run zensical build`, then uploads
-the `site/` directory to GitHub Pages.
+the `site/` directory to GitHub Pages. The `deploy` job only runs when the
+repository variable `DEPLOY_DOCS` is `"true"`.
 
 ### `publish.yml` / `publish_testpypi.yml`
 
 **Triggers:** `workflow_dispatch` with a tag and environment selection.
 
-Build with `uv build`, smoke-test artifacts, then `uv publish`. These workflows
-also use `continue-on-error: true` on the publish step so the template stays
-green until you configure PyPI trusted publishing and GitHub environments.
+Build with `uv build`, then publish with `pypa/gh-action-pypi-publish` in the
+`publish-to-pypi` / `publish-to-testpypi` job. Those jobs only run when the
+repository variable `PUBLISH_TO_PYPI` / `PUBLISH_TO_TESTPYPI` (respectively) is
+`"true"`.
 
 ### `support_floor_update.yml` (Support floor update)
 
@@ -185,12 +187,23 @@ rules you want, then configure
 this repository’s **`scheduled_release.yml`** and **`publish.yml`** (or the
 TestPyPI workflow) together with the matching environment name.
 
-### Remove `continue-on-error` for real packages
+### Enable publishing and docs deployment with repository variables
 
-The template tolerates missing PyPI configuration. For production, remove
-`continue-on-error: true` from the publish steps (for example in
-`scheduled_release.yml` near the `uv publish` step, and in `publish.yml` /
-`publish_testpypi.yml`) so failed uploads fail the workflow.
+By default the template ships with publishing and documentation deployment
+disabled, so a freshly generated repository stays green with no PyPI or Pages
+setup. Each gated job checks a repository variable (**Settings → Secrets and
+variables → Actions → Variables**) and only runs when it is set to the string
+`"true"`:
+
+| Variable              | Gates                                                                     |
+| --------------------- | ------------------------------------------------------------------------- |
+| `PUBLISH_TO_PYPI`     | `publish.yml` (`publish-to-pypi`) and `scheduled_release.yml` (`publish`) |
+| `PUBLISH_TO_TESTPYPI` | `publish_testpypi.yml` (`publish-to-testpypi`)                            |
+| `DEPLOY_DOCS`         | `documentation.yml` (`deploy`)                                            |
+
+Set the relevant variable(s) to `true` once the matching GitHub environment,
+PyPI trusted publisher, and/or GitHub Pages source are configured. Leave a
+variable unset (or any value other than `"true"`) to keep that job disabled.
 
 ## Customization
 
@@ -225,8 +238,14 @@ Remove or gate the `codeql` job in `scheduled_release.yml` instead of editing
 
 ### PyPI publish is skipped or succeeds silently
 
-- Check for `continue-on-error: true` on publish steps
-- Verify the `pypi` environment and trusted publisher mapping
+- Confirm the `PUBLISH_TO_PYPI` (or `PUBLISH_TO_TESTPYPI`) repository variable
+  is set to `"true"` — the publish job is skipped entirely otherwise
+- Verify the `pypi` / `testpypi` environment and trusted publisher mapping
+
+### Documentation deploy is skipped
+
+- Confirm the `DEPLOY_DOCS` repository variable is set to `"true"`
+- Verify GitHub Pages is enabled with source **GitHub Actions**
 
 ## Resources
 

--- a/docs/template_documentation/user_guide/documentation.md
+++ b/docs/template_documentation/user_guide/documentation.md
@@ -266,6 +266,11 @@ To deploy your documentation to GitHub Pages, follow these steps:
     - **Source**: Select "GitHub Actions"
     - This allows the documentation workflow to deploy directly
 4. Click **Save**
+5. Navigate to **Settings** → **Secrets and variables** → **Actions** →
+   **Variables** and add a repository variable named `DEPLOY_DOCS` with the
+   value `true`. The `deploy` job in `documentation.yml` only runs when this
+   variable is set to `"true"`, so this step is required before the workflow
+   will publish anything.
 
 ### 2. Configure Site URL (Optional but Recommended)
 


### PR DESCRIPTION
## Summary
- `publish.yml` / `publish_testpypi.yml`: the publish jobs now only run when the repository variable `PUBLISH_TO_PYPI` / `PUBLISH_TO_TESTPYPI` is set to `"true"`, replacing the previous `continue-on-error: true` workaround.
- `scheduled_release.yml`: the `publish` job is gated the same way on `PUBLISH_TO_PYPI`.
- `documentation.yml`: the `deploy` job is gated on `DEPLOY_DOCS` being `"true"`.
- Updated `docs/template_documentation/user_guide/ci_cd.md` and `documentation.md` to document the new repository variables and how to enable them.

## Test plan
- [ ] `uv run --frozen prek run --all-files` passes locally (ran on changed files)
- [ ] Confirm workflow YAML is valid (parsed with `yaml.safe_load`)
- [ ] After merge, verify jobs are skipped with the variables unset, and run when set to `true` with a real PyPI trusted publisher / GitHub Pages configured