### PR TITLE
feat(github): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,56 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve
+title: '[BUG]: '
+labels: bug
+assignees: ''
+---
+
+## 📝 Description
+
+A clear and concise description of what the bug is.
+
+## 🚀 Reproduction Steps
+
+Steps to reproduce the behavior:
+
+1. '...'
+2. '...'
+3. '...'
+
+## 💻 Minimal Reproducible Example
+
+Please provide a short snippet of Python code that demonstrates the issue. Use
+code blocks for readability:
+
+```python
+# Your code here
+```
+
+## 📋 Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## 💥 Actual Behavior / Traceback
+
+If applicable, add the Python error traceback here **after redacting secrets**
+(API keys, tokens, credentials, private URLs/paths, personal data). If this is a
+potential security vulnerability, do **not** post it publicly; use the Security
+reporting channel instead.
+
+```text
+Traceback (most recent call last):
+  ...
+
+```
+
+## 🛠 Environment Information
+
+- **Python Version:** (e.g., 3.13)
+- **Package Version:** (e.g., 1.2.3)
+- **Operating System:** (e.g., Windows 11, Ubuntu 22.04, macOS)
+- **Relevant Dependencies:** (e.g., numpy, pandas version if applicable)
+
+## 📎 Additional Context
+
+Add any other context about the problem here (e.g., screenshots, logs).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: GitHub Community Support
+      url: https://github.com/isaac-cf-wong/python-package-template/discussions
+      about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,47 @@
+---
+name: ✨ Feature Request
+about: Suggest an idea or improvement for this package
+title: '[FEATURE]: '
+labels: enhancement
+assignees: ''
+---
+
+## 🎯 Problem Statement
+
+Is your feature request related to a problem? Please describe.
+
+> _Ex: "I'm always frustrated when I have to manually loop over X to achieve
+> Y..."_
+
+## 💡 Proposed Solution
+
+A clear and concise description of what you want to happen. Describe the new
+functionality or the change to existing behavior.
+
+## 💻 Proposed API / Usage Example
+
+If applicable, show how you would imagine the Python code looking with this new
+feature:
+
+```python
+import package_name_placeholder
+
+# How you'd like to use the new feature
+result = package_name_placeholder.new_function(param="example")
+
+```
+
+## 🌈 Use Case & Benefits
+
+Why is this feature important to you and other users? How does it improve the
+package?
+
+## 🔄 Alternatives Considered
+
+A clear and concise description of any alternative solutions or workarounds
+you've considered (e.g., using a different library or a custom wrapper).
+
+## ⚠️ Additional Context
+
+Add any other context, screenshots, or links to similar implementations in other
+libraries here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+---
+name: 🚀 Pull Request
+about: Submit your changes for review
+---
+
+## 📝 Summary
+
+Briefly describe the changes introduced by this PR. Mention any related issues
+using keywords (e.g., `Closes #123`).
+
+## ✨ Type of Change
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
+      to not work as expected)
+- [ ] 📝 Documentation update
+- [ ] 🎨 Refactoring (no functional changes, no API changes)
+
+## 🧪 How Has This Been Tested
+
+Please describe the tests that you ran to verify your changes.
+
+- [ ] **Unit Tests:** `uv run pytest tests/test_feature.py`
+- [ ] **Manual Test:** (Describe steps)
+
+## 🏗️ Checklist
+
+- [ ] My code follows the style guidelines of this project (PEP 8).
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] My changes generate no new warnings.
+- [ ] I have added tests that prove my fix is effective or that my feature
+      works.
+
+## 📷 Screenshots (if applicable)
+
+If this is a UI change or produces a specific output/graph, add screenshots
+here.


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/bug-report.md` and `feature-request.md`, plus `config.yml` (disables blank issues, links to GitHub Discussions).
- Add `.github/pull_request_template.md` with a summary, type-of-change checklist, testing section, and review checklist.
- Mirrors the templates already used in the `gwmock` repo, adapted for this template's placeholder package name and repo URL.

## Test plan
- [x] `uv run --frozen prek run` passes on the new files (prettier, markdownlint-cli2, typos, etc.)
- [ ] Open a test issue/PR on GitHub to confirm the templates render as expected