### PR TITLE
fix(ci): hold the major back while the package is pre-1.0

### DIFF
--- a/.github/workflows/scheduled_release.yml
+++ b/.github/workflows/scheduled_release.yml
@@ -4,6 +4,17 @@ on:
     schedule:
         - cron: '0 0 * * 2'
     workflow_dispatch:
+        inputs:
+            allow_major_bump:
+                description:
+                    'Let a breaking change bump 0.x.y into 1.0.0. Off by
+                    default: while the package is pre-1.0 a breaking change
+                    bumps the minor instead, because 1.x declares a stable API.
+                    Has no effect once the current major is >= 1, where a major
+                    bump is enforced anyway.'
+                required: false
+                default: false
+                type: boolean
 
 permissions:
     contents: write
@@ -59,12 +70,37 @@ jobs:
 
             - name: Bump version and push tag
               id: tag_version
+              env:
+                  # The flag itself, or empty, so the shell never has to interpret a truth value.
+                  # The `inputs` context keeps a typed boolean as a boolean, so this expression is
+                  # sound; `github.event.inputs` would have handed over the *string* `false`, which is
+                  # truthy in a shell test and would have passed `--allow-major-bump` on every run that
+                  # left it off. Resolving it here rather than in `run:` keeps that distinction from
+                  # mattering. On a `schedule` event `inputs` is absent, which is falsy -- the default.
+                  ALLOW_MAJOR_BUMP:
+                      ${{ inputs.allow_major_bump && '--allow-major-bump' || ''
+                      }}
               run: |
+                  set -euo pipefail
                   PREVIOUS_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
                   if [ "$PREVIOUS_TAG" = "none" ]; then
                     NEW_TAG="v0.1.0"
                   else
-                    NEW_TAG=$(uv run --frozen git-cliff --bumped-version --config cliff.toml 2>/dev/null)
+                    # git-cliff proposes; `release_version.py` decides. Its default sends a breaking
+                    # change straight to the next major, which is right once an API has been promised
+                    # and wrong before: at v0.10.2 it answers v1.0.0, publishing a stable-API claim as
+                    # a side effect of a bug fix. While the major is 0 that is demoted to a minor bump
+                    # unless this run was dispatched with allow_major_bump. At 1.x and above the
+                    # proposal is taken unchanged.
+                    #
+                    # The `2>/dev/null` that used to be here is gone deliberately: it hid git-cliff
+                    # failing, and an empty NEW_TAG would then have been tagged as the empty string.
+                    PROPOSED_TAG=$(uv run --frozen git-cliff --bumped-version --config cliff.toml)
+                    NEW_TAG=$(uv run --frozen python scripts/release_version.py \
+                      --current "$PREVIOUS_TAG" \
+                      --proposed "$PROPOSED_TAG" \
+                      ${ALLOW_MAJOR_BUMP})
+                    echo "git-cliff proposed $PROPOSED_TAG; releasing $NEW_TAG"
                   fi
                   if ! git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
                     echo "Creating annotated tag $NEW_TAG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ fail_under = 0
 
 [tool.pytest.ini_options]
 addopts = "--cov-report xml:coverage.xml --cov src --cov-append -m 'not integration' --cov-report=term-missing"
-pythonpath = ["src"]
+pythonpath = ["src", "scripts"]
 testpaths = "tests"
 junit_family = "xunit2"
 markers = [

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -1,0 +1,150 @@
+"""Decide the version the next release ships under, given git-cliff's proposal.
+
+The scheduled release asks `git-cliff --bumped-version` for a tag. git-cliff's default sends a breaking
+change to the next major, which is right for a package that has promised an API and wrong for one that
+has not: at `v0.10.2` a breaking change answers `v1.0.0`. That would publish a stable-API claim as a
+side effect of a fix that only renames things.
+
+The rule this applies:
+
+    while the current version is `0.x.y`, a proposed major bump is demoted to a minor bump, unless the
+    release was run with `allow_major_bump`; once the current major is `>= 1`, git-cliff's answer stands
+    untouched.
+
+`cliff.toml` cannot express that. `[bump] breaking_always_bump_major = false` would also disable the
+enforced major bump at `>= 1`, which is the half worth keeping -- so the decision is post-processing on
+git-cliff's answer rather than configuration of it.
+
+Run as a script it takes the two versions and prints the answer, which is what the workflow uses:
+
+    python scripts/release_version.py --current v0.4.1 --proposed "$(git-cliff --bumped-version)"
+
+It lives in `scripts/` rather than in `src/`: it is release tooling and has no business in the wheel.
+`pyproject.toml` puts `scripts` on the test path so it is covered like anything else, because a wrong
+answer here is both expensive and silent -- a version cannot be unpublished, and nothing downstream
+would flag `1.0.0` as unintended.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+#: A release tag: an optional `v`, then exactly three dot-separated numbers. Deliberately strict --
+#: pre-release and build metadata are not used by this project's tags, and a tag shape nobody expected
+#: is a reason to stop the release rather than to guess at it.
+_VERSION = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+def _parse(version: str, *, described_as: str) -> tuple[int, int, int]:
+    """Return the numeric components of *version*.
+
+    Args:
+        version: The tag, with or without a leading `v`.
+        described_as: What to call it in the message, so a failure names which of the two was wrong.
+
+    Returns:
+        The major, minor and patch components.
+
+    Raises:
+        ValueError: If the version is not `<major>.<minor>.<patch>`, optionally `v`-prefixed.
+    """
+    matched = _VERSION.match(version.strip())
+    if matched is None:
+        raise ValueError(
+            f"could not read {described_as} {version!r} as a version: expected `<major>.<minor>.<patch>`, "
+            f"optionally prefixed with `v`. Refusing to guess, because the answer becomes a published tag."
+        )
+    major, minor, patch = matched.groups()
+    return int(major), int(minor), int(patch)
+
+
+def choose_version(*, current: str, proposed: str, allow_major_bump: bool = False) -> str:
+    """Return the version to release, holding the major back while the package is pre-1.0.
+
+    Args:
+        current: The latest released tag, e.g. from `git describe --tags --abbrev=0`.
+        proposed: What `git-cliff --bumped-version` suggests.
+        allow_major_bump: Take the proposal even if it crosses into `1.x`. This is the explicit
+            negotiation the rule leaves open; it does nothing once the current major is `>= 1`, where a
+            major bump is enforced anyway.
+
+    Returns:
+        The tag to create, carrying the `v` prefix if *proposed* had one.
+
+    Raises:
+        ValueError: If either version is unreadable, or the proposal is not ahead of the current version.
+    """
+    current_parts = _parse(current, described_as="the current version")
+    proposed_parts = _parse(proposed, described_as="the proposed version")
+    current_major, current_minor, _ = current_parts
+    proposed_major = proposed_parts[0]
+
+    # Checked before the rule is applied, because both numbers are only visible here. A proposal that is
+    # not ahead means git-cliff ran against the wrong history, and the release would either collide with
+    # an existing tag or publish a version that reads as older than the one before it.
+    if proposed_parts <= current_parts:
+        raise ValueError(
+            f"the proposed version {proposed!r} is not ahead of the current version {current!r}. "
+            f"git-cliff was run against unexpected history; releasing this would either collide with an "
+            f"existing tag or publish a version that reads as older."
+        )
+
+    # Normalised once, and it is the normalised form that is returned. Validating a stripped copy while
+    # returning the original meant `" v2.0.0 "` passed the parser and came back with its spaces, and
+    # `git check-ref-format 'refs/tags/ v2.0.0 '` refuses that -- so the release would have failed at the
+    # tag, with a message about ref format rather than about where the whitespace came from. The demoted
+    # path was never exposed to it, since it builds its answer out of parsed numbers. The general shape
+    # of the bug: validating a copy is not validating the thing you return.
+    #
+    # Not cosmetic in practice: the proposal arrives from `$(git-cliff ...)`, and command substitution
+    # strips trailing newlines but nothing else.
+    proposed = proposed.strip()
+    prefix = "v" if proposed.startswith("v") else ""
+
+    # The rule applies to exactly one situation: a 0.x package being pushed to 1.0 by a breaking change.
+    # Everything else -- 0.x staying in 0.x, and any bump at 1.x or above -- is git-cliff's answer.
+    demote = current_major == 0 and proposed_major > current_major and not allow_major_bump
+    if not demote:
+        return proposed
+
+    # A minor bump, with the patch reset: this is a 0.x minor release, not a major one wearing a smaller
+    # number. `0.10.1` -> `0.11.0`.
+    return f"{prefix}{current_major}.{current_minor + 1}.0"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the version to release.
+
+    Args:
+        argv: Command-line arguments, for testing; defaults to `sys.argv[1:]`.
+
+    Returns:
+        The process exit status: 0 on success, 2 if the versions could not be used.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--current", required=True, help="the latest released tag")
+    parser.add_argument("--proposed", required=True, help="the tag git-cliff proposes")
+    parser.add_argument(
+        "--allow-major-bump",
+        action="store_true",
+        help="accept a bump into the next major while the current major is 0",
+    )
+    arguments = parser.parse_args(argv)
+    try:
+        print(
+            choose_version(
+                current=arguments.current,
+                proposed=arguments.proposed,
+                allow_major_bump=arguments.allow_major_bump,
+            )
+        )
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,148 @@
+"""Which version the next release ships under.
+
+The scheduled release asks `git-cliff --bumped-version` for the tag, and git-cliff's default takes a
+breaking change straight to the next major. At `v0.10.2`, with a breaking change merged, that answer is
+`v1.0.0` -- and `v1.x` declares a stable API a pre-1.0 package is not ready to promise.
+
+So the rule, and what these tests pin:
+
+    while the current version is 0.x.y, a breaking change bumps the *minor*, not the major, unless the
+    release is run with `allow_major_bump` -- and once the current major is >= 1, git-cliff's answer
+    stands untouched.
+
+This is decided in a module rather than in workflow shell because a wrong answer here is expensive and
+silent: a version cannot be unpublished, and nothing downstream would flag `1.0.0` as unintended.
+"""
+
+from __future__ import annotations
+
+import pytest
+from release_version import choose_version
+
+pytestmark = pytest.mark.unit
+
+
+class TestZeroVerHoldsTheMajorBack:
+    """0.x.y is the case the rule exists for."""
+
+    @pytest.mark.parametrize(
+        ("current", "proposed", "expected"),
+        [
+            ("v0.10.1", "v1.0.0", "v0.11.0"),
+            ("v0.1.0", "v1.0.0", "v0.2.0"),
+            ("v0.0.1", "v1.0.0", "v0.1.0"),
+            ("v0.99.99", "v1.0.0", "v0.100.0"),
+        ],
+    )
+    def test_a_proposed_major_bump_becomes_a_minor_bump(self, current: str, proposed: str, expected: str) -> None:
+        """The live case: `v0.10.1` + a breaking change gives `v0.11.0`, not `v1.0.0`.
+
+        The patch component resets, because this is a minor bump and not a re-labelled major one.
+        """
+        assert choose_version(current=current, proposed=proposed) == expected
+
+    @pytest.mark.parametrize(
+        ("current", "proposed"),
+        [
+            ("v0.10.1", "v0.11.0"),
+            ("v0.10.1", "v0.10.2"),
+            ("v0.1.0", "v0.1.1"),
+        ],
+    )
+    def test_a_proposal_that_is_not_a_major_bump_is_untouched(self, current: str, proposed: str) -> None:
+        """Only the major bump is demoted. Feature and fix bumps are git-cliff's business."""
+        assert choose_version(current=current, proposed=proposed) == proposed
+
+    def test_the_input_can_still_ask_for_the_major(self) -> None:
+        """`allow_major_bump` is the negotiation the rule leaves open -- 1.0.0 when it is meant."""
+        assert choose_version(current="v0.10.1", proposed="v1.0.0", allow_major_bump=True) == "v1.0.0"
+
+
+class TestOnceStableTheMajorIsEnforced:
+    """At `>= 1` the rule does not apply, and a breaking change bumps the major without negotiation."""
+
+    @pytest.mark.parametrize(
+        ("current", "proposed"),
+        [
+            ("v1.0.0", "v2.0.0"),
+            ("v1.4.2", "v2.0.0"),
+            ("v9.9.9", "v10.0.0"),
+        ],
+    )
+    def test_a_major_bump_stands(self, current: str, proposed: str) -> None:
+        """git-cliff's answer is taken unchanged, `allow_major_bump` or not."""
+        assert choose_version(current=current, proposed=proposed) == proposed
+        assert choose_version(current=current, proposed=proposed, allow_major_bump=False) == proposed
+
+    def test_a_minor_bump_at_one_point_x_stands(self) -> None:
+        """The guard must not reach past the case it is for."""
+        assert choose_version(current="v1.4.2", proposed="v1.5.0") == "v1.5.0"
+
+
+class TestTheShapesItRefuses:
+    """A release tag is not a place to be lenient about what it was handed."""
+
+    @pytest.mark.parametrize("current", ["", "v", "0.10", "vx.y.z", "v0.10.1.2", "1.0.0-rc1+build"])
+    def test_an_unparsable_current_version_is_refused(self, current: str) -> None:
+        """Guessing here would silently ship a wrong version, which cannot be withdrawn."""
+        with pytest.raises(ValueError, match="could not read"):
+            choose_version(current=current, proposed="v1.0.0")
+
+    @pytest.mark.parametrize("proposed", ["", "v", "not-a-version"])
+    def test_an_unparsable_proposal_is_refused(self, proposed: str) -> None:
+        """git-cliff printing something unexpected must stop the release, not be pattern-matched past."""
+        with pytest.raises(ValueError, match="could not read"):
+            choose_version(current="v0.10.1", proposed=proposed)
+
+    def test_a_proposal_that_goes_backwards_is_refused(self) -> None:
+        """Not the rule's business, but it is the one place that sees both numbers.
+
+        A proposal below the current version means git-cliff was run against the wrong history, and the
+        release would either fail on an existing tag or publish a version that reads as older.
+        """
+        with pytest.raises(ValueError, match="not ahead of"):
+            choose_version(current="v0.10.1", proposed="v0.9.0")
+
+    def test_the_same_version_is_refused(self) -> None:
+        """A release that does not move the version has nothing to release."""
+        with pytest.raises(ValueError, match="not ahead of"):
+            choose_version(current="v0.10.1", proposed="v0.10.1")
+
+
+class TestTheFormatItReturns:
+    """The tag is used verbatim by `git tag`, so its shape is part of the contract."""
+
+    def test_the_v_prefix_is_preserved(self) -> None:
+        """Every tag in this repo carries it, and the workflow does not add one."""
+        assert choose_version(current="v0.10.1", proposed="v1.0.0").startswith("v")
+
+    def test_a_prefixless_current_is_accepted_and_the_proposal_s_shape_is_kept(self) -> None:
+        """`git describe` and git-cliff both emit the `v`, but neither is guaranteed to."""
+        assert choose_version(current="0.10.1", proposed="1.0.0") == "0.11.0"
+
+
+class TestWhitespaceNeverReachesTheTag:
+    """The returned string goes straight to `git tag`, so it has to be a tag.
+
+    The parser stripped before matching, and the untouched path then returned the *original* string --
+    so `" v2.0.0 "` was validated as `v2.0.0` and emitted with its spaces intact, and
+    `git check-ref-format 'refs/tags/ v2.0.0 '` rejects that. The demoted path happened to be safe,
+    because it rebuilds the string from parsed numbers rather than passing one through. Validating a
+    normalised copy and returning the raw one is the gap.
+    """
+
+    @pytest.mark.parametrize(
+        ("current", "proposed", "expected"),
+        [
+            ("v1.0.0", " v2.0.0 ", "v2.0.0"),
+            ("v1.0.0", "v2.0.0\n", "v2.0.0"),
+            ("v0.10.2", "  v0.11.0", "v0.11.0"),
+        ],
+    )
+    def test_the_untouched_path_returns_a_clean_tag(self, current: str, proposed: str, expected: str) -> None:
+        """A proposal taken unchanged is still normalised -- `git-cliff` output can carry a newline."""
+        assert choose_version(current=current, proposed=proposed) == expected
+
+    def test_the_demoted_path_is_clean_too(self) -> None:
+        """It always was, since it composes the string; asserted so both paths are pinned together."""
+        assert choose_version(current="v0.10.2", proposed=" v1.0.0 ") == "v0.11.0"


### PR DESCRIPTION
## 📝 Summary

The scheduled release takes its tag from `git-cliff --bumped-version`, whose
default sends a breaking change to the next major — right once an API has been
promised, wrong before it. While the current version is `0.x.y`, a proposed
major bump is now demoted to a minor bump (patch reset); once the current major
is `>= 1`, git-cliff's answer stands untouched. A new `allow_major_bump`
workflow input takes the proposal anyway, which is how `1.0.0` gets released
when it is meant.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested

The decision logic lives in `scripts/release_version.py`, covered by 29 unit
tests in `tests/test_release_version.py` that pin the demotion, the untouched
paths, the `>= 1` enforcement, and the tag-shape guard rails. Run locally:

- [x] **Unit Tests:** `uv run pytest` — 45 passed
- [ ] **Manual Test:** (Describe steps)

Also verified: `ruff check` clean, all pre-commit hooks pass (incl. actionlint
on the workflow).

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature
      works.

## 📷 Screenshots (if applicable)

N/A — CI change only.